### PR TITLE
Update GitHub Actions workflow to trigger on published releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types:
+      - published
   
 name: Deploy Extension
 jobs:


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration to trigger the deployment process on release events instead of tag pushes.

Workflow configuration updates:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L2-R4): Modified the workflow to trigger on `release` events with `published` types instead of `push` events with tags.