### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,7 +24,7 @@ jobs:
         run: sudo apt-get install -y jq
       
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       
       - name: Set up Git
         run: |
@@ -32,7 +32,7 @@ jobs:
           git config --global user.email "actions@github.com"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: 20
 
@@ -55,7 +55,7 @@ jobs:
       VERSION: ${{ steps.set_version.outputs.VERSION }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Set up Git
         run: |
@@ -101,7 +101,7 @@ jobs:
       MASTER_PUSH_DONE: ${{ steps.mark_push.outputs.MASTER_PUSH_DONE }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Set up Git
         run: |
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           ref: master
@@ -160,7 +160,7 @@ jobs:
           git checkout master
           git pull origin master
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.1.0
         with:
           node-version: 20
       

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -9,7 +9,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/first-interaction@v1
+    - uses: actions/first-interaction@v1.3.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: "Thanks for opening this issue!"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,10 +18,10 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v4.1.0
       with:
         node-version: 20
-    - uses: actions/stale@v5
+    - uses: actions/stale@v9.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 31

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.1.0](https://github.com/actions/setup-node/releases/tag/v4.1.0)** on 2024-10-24T13:51:16Z
* **[actions/first-interaction](https://github.com/actions/first-interaction)** published a new release **[v1.3.0](https://github.com/actions/first-interaction/releases/tag/v1.3.0)** on 2023-11-29T14:14:13Z
* **[actions/stale](https://github.com/actions/stale)** published a new release **[v9.0.0](https://github.com/actions/stale/releases/tag/v9.0.0)** on 2023-12-07T12:30:54Z
