### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: reitermarkus/automerge@v2
+      - uses: reitermarkus/automerge@v2.8.0
         with:
           token: ${{ secrets.WORKFLOW_TOKEN }}
           do-not-merge-labels: never-merge


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[reitermarkus/automerge](https://github.com/reitermarkus/automerge)** published a new release **[v2.8.0](https://github.com/reitermarkus/automerge/releases/tag/v2.8.0)** on 2024-02-27T10:01:59Z
