### PR TITLE
Add project template snippet and mark existing snippets as file templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Learn more about available snippets in the sections below.
 | `ziglove` | Prints 'I love ZIG!' to the console |
 | `zighello`, `helloworld` | Prints 'Hello, World!' to the console |
 | `launch`, `startup` | Initializes a main function |
+| `project`, `template` | Creates a new project template |
 | `import` | Import a module using @import |
 | `import_std`, `imps` | Import the standard library |
 | `import_builtin`, `impb` | Import the builtin module |

--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -23,7 +23,8 @@
             "\tstd.debug.print(\"Hello, {s}!\\n\", .{\"World\"});",
             "}"
         ],
-        "description": "Prints 'Hello, World!' to the console"
+        "description": "Prints 'Hello, World!' to the console",
+        "isFileTemplate": true
     },
     "launch": {
         "prefix": ["launch", "startup"],
@@ -36,6 +37,25 @@
             ""
         ],
         "description": "Initializes a main function",
+        "isFileTemplate": true
+    },
+    "project template": {
+        "prefix": ["project", "template"],
+        "body": [
+            "const std = @import(\"std\");",
+            "",
+            "fn ${1:name}($2)${3| !, |}${4:void} {",
+            "\t",
+            "}",
+            "",
+            "pub fn main() !void {",
+            "\t$0",
+            "\t",
+            "\t${1:name}();",
+            "}",
+            ""
+        ],
+        "description": "Creates a new project template",
         "isFileTemplate": true
     },
     "import": {


### PR DESCRIPTION
This pull request includes updates to the `snippets/snippets.code-snippets` file, adding new template options and modifying existing ones for better functionality.

Enhancements to snippets:

* Added `isFileTemplate` property to the "Prints 'Hello, World!'" snippet to indicate it can be used as a file template.
* Added a new "project template" snippet, which provides a template for creating a new project with a main function and an additional customizable function.