### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -204,7 +204,7 @@ jobs:
           fi
 
       - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v1.6.2
+        uses: HaaLeo/publish-vscode-extension@v2.0.0
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[HaaLeo/publish-vscode-extension](https://github.com/HaaLeo/publish-vscode-extension)** published a new release **[v2.0.0](https://github.com/HaaLeo/publish-vscode-extension/releases/tag/v2.0.0)** on 2025-02-23T11:38:43Z
